### PR TITLE
Support IPv6, use Origin image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/openshift3/ose-haproxy-router
+FROM docker.io/openshift/origin-haproxy-router:v1.3.1
 
 ADD haproxy-config.template.patch /var/lib/haproxy/conf
 USER root

--- a/haproxy-config.template.patch
+++ b/haproxy-config.template.patch
@@ -1,8 +1,16 @@
---- haproxy-config.template.orig	2016-07-04 19:41:59.378274681 +0200
-+++ haproxy-config.template	2016-05-12 14:12:56.874518626 +0200
-@@ -63,9 +63,14 @@
+--- haproxy-config.template.orig	2016-11-21 14:32:18.260057025 +0100
++++ haproxy-config.template	2016-11-21 15:23:23.172753955 +0100
+@@ -89,6 +89,7 @@
+ 
+ frontend public
+   bind :{{env "ROUTER_SERVICE_HTTP_PORT" "80"}}
++  bind :::{{env "ROUTER_SERVICE_HTTP_PORT" "80"}} v6only
+   mode http
    tcp-request inspect-delay 5s
    tcp-request content accept if HTTP
+@@ -96,9 +97,14 @@
+   # Remove port from Host header
+   http-request replace-header Host (.*):.* \1
  
 +  acl path_letsencrypt path_beg /.well-known/acme-challenge/
 +  acl path_letsencrypt path_beg /.well-known/letsencrypt
@@ -16,3 +24,11 @@
  
    # Check if it is an edge route exposed insecurely.
    acl edge_http_expose base,map_beg(/var/lib/haproxy/conf/os_edge_http_expose.map) -m found
+@@ -117,6 +123,7 @@
+ # that terminates encryption in this router (edge)
+ frontend public_ssl
+   bind :{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}}
++  bind :::{{env "ROUTER_SERVICE_HTTPS_PORT" "443"}} v6only
+   tcp-request  inspect-delay 5s
+   tcp-request content accept if { req_ssl_hello_type 1 }
+ 


### PR DESCRIPTION
* Listen on IPv4 and IPv6 (the latter may or may not be exposed)
* Use OpenShift Origin image as base (`openshift/origin-haproxy-router`); local builds can override that to use RedHat's image