### PR TITLE
Fix backend name for acme-challenge

### DIFF
--- a/patch-letsencrypt.sh
+++ b/patch-letsencrypt.sh
@@ -8,7 +8,7 @@ sed -e 's|redirect scheme https if secure_redirect|\
 \
   redirect scheme https if secure_redirect !path_letsencrypt\
 \
-  use_backend be_http:%[env(LETSENCRYPT_HOST),map_reg(/var/lib/haproxy/conf/os_http_be.map)] if path_letsencrypt\
+  use_backend be_http_%[env(LETSENCRYPT_HOST),map_reg(/var/lib/haproxy/conf/os_http_be.map)] if path_letsencrypt\
 \
 |' <$1 >$1.tmp
 


### PR DESCRIPTION
Origin 1.4 and 1.5 still use `_` as the separator, not `:`